### PR TITLE
fix: namespace collisions in Unreal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ xcuserdata/
 
 # Mac
 .DS_Store
+
+# Built xcframework
+CrashReporter.xcframework/

--- a/Source/PLCrashNamespace.h
+++ b/Source/PLCrashNamespace.h
@@ -35,7 +35,7 @@
  * This may be used to avoid symbol conflicts between multiple libraries
  * that may both incorporate PLCrashReporter.
  */
-// #define PLCRASHREPORTER_PREFIX AcmeCo
+#define PLCRASHREPORTER_PREFIX BugSplat
 
 
 // We need two extra layers of indirection to make CPP substitute


### PR DESCRIPTION
Prefixes all PLCrashReporter symbols with `BugSplat` to avoid naming collisions