### PR TITLE
fix: use com.bugsplat cache directory to avoid conflicts

### DIFF
--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -54,7 +54,7 @@
 
 /** @internal
  * CrashReporter cache directory name. */
-static NSString *PLCRASH_CACHE_DIR = @"com.plausiblelabs.crashreporter.data";
+static NSString *PLCRASH_CACHE_DIR = @"com.bugsplat.crashreporter.data";
 
 /** @internal
  * Crash Report file name. */


### PR DESCRIPTION
## Summary
Change the crash report cache directory from `com.plausiblelabs.crashreporter.data` to `com.bugsplat.crashreporter.data`.

## Why
When multiple PLCrashReporter instances exist in the same process (e.g., Unity bundles its own `UnityPLCrashReporter`), they both write to `com.plausiblelabs.crashreporter.data/<bundle-id>/live_report.plcrash`. The other instance's crash report (without BugSplat's customData) overwrites ours, causing attributes, notes, and user info to be lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)